### PR TITLE
chore: Upgrade inline-style-prefixer@^1.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "test": "npm run build && mocha --recursive --compilers js:babel-core/register",
     "build": "babel modules --out-dir lib",
-		"release": "npm run build && npm publish"
+    "release": "npm run build && npm publish"
   },
   "repository": {
     "type": "git",
@@ -44,6 +44,6 @@
     "sinon-chai": "^2.8.0"
   },
   "dependencies": {
-    "inline-style-prefixer": "^0.6.2"
+    "inline-style-prefixer": "^1.0.3"
   }
 }

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -2,15 +2,40 @@ import { expect } from 'chai'
 import radiumPluginPrefixAll from '../lib/index'
 
 describe('Adding all vendor prefixes', () => {
-  it('should add all major vendor prefixes', () => {
+  it('should add all major vendor prefixes for hyphens', () => {
+    const input = {hyphens: 'auto'}
+    const output = {
+      WebkitHyphens: 'auto',
+      MozHyphens: 'auto',
+      msHyphens: 'auto',
+      hyphens: 'auto'
+    }
+    expect(radiumPluginPrefixAll({style: input})).to.deep.eql({
+      style: output
+    })
+  })
+
+  it('should add necessary prefixes for flex-direction', () => {
     const input = {flexDirection: 'row'}
     const output = {
       WebkitFlexDirection: 'row',
-      MozFlexDirection: 'row',
+      // MozFlexDirection: 'row', // No longer necessary
       msFlexDirection: 'row',
       flexDirection: 'row',
       WebkitBoxDirection: 'normal',
       WebkitBoxOrient: 'horizontal'
+    }
+    expect(radiumPluginPrefixAll({style: input})).to.deep.eql({
+      style: output
+    })
+  })
+
+  it('should add necessary prefixes for transform', () => {
+    const input = {transform: 'rotate(30deg)'}
+    const output = {
+      WebkitTransform: 'rotate(30deg)',
+      msTransform: 'rotate(30deg)',
+      transform: 'rotate(30deg)'
     }
     expect(radiumPluginPrefixAll({style: input})).to.deep.eql({
       style: output


### PR DESCRIPTION
This PR upgrades `inline-style-prefixer@^1.0.3`. We've seen some nice perf improvements on this major bump.

Also added/updated tests.
